### PR TITLE
refactored command name from 'eloquent-filter:make' to 'make:eloquent…

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ You may prefix the name with the path, like `Models/Product/NameFilter`.
 php artisan make:eloquent-filter Models/Product/NameFilter
 ```
 
-You can use the `--field name` argument to generate your filter with the field name
+You can use the `--field=name` argument to generate your filter with the field name
 ```bash
-php artisan make:eloquent-filter Models/Product/NameFilter --field name
+php artisan make:eloquent-filter Models/Product/NameFilter --field=name
 ```
 
 Here is what your `NameFilter` might look like:

--- a/README.md
+++ b/README.md
@@ -37,8 +37,22 @@ class ProductsController
     }
 }
 ```
-You can generate a filter with the command `php artisan eloquent-filter:make NameFilter`. This will put your Filter to the app/Filters directory by default.
+
+Generate eloquent-filter
+```bash
+php artisan make:eloquent-filter NameFilter
+```
+
+This will put your Filter to the app/Filters directory by default.
 You may prefix the name with the path, like `Models/Product/NameFilter`.
+```bash
+php artisan make:eloquent-filter Models/Product/NameFilter
+```
+
+You can use the `--field name` argument to generate your filter with the field name
+```bash
+php artisan make:eloquent-filter Models/Product/NameFilter --field name
+```
 
 Here is what your `NameFilter` might look like:
 
@@ -55,7 +69,7 @@ class NameFilter extends AbstractEloquentFilter
         $this->name = $name;
     }
 
-    public function apply(Builder $builder): Builder
+    public function apply(Builder $query): Builder
     {
         return $query->where('name', 'like', "{$this->name}%");
     }
@@ -184,7 +198,7 @@ class StoreWithinDistanceFilter extends AbstractEloquentFilter
         $this->fromCoordinates = $fromCoordinates;
     }
 
-    public function apply(Builder $builder): Builder
+    public function apply(Builder $query): Builder
     {
         return $builder->join('stores', 'stores.id', '=', 'product_stock.store_id')
             ->whereRaw('
@@ -242,7 +256,7 @@ class StoreWithinDistanceFilter extends AbstractEloquentFilter
         return $this->distance && is_numeric($this->distance);
     }
 
-    public function apply(Builder $bulder): Builder
+    public function apply(Builder $query): Builder
     {
         // your code
     }
@@ -267,7 +281,7 @@ class ProductsController
 ## Testing
 
 ```bash
-vendor/bin/phpunit
+composer test
 ```
 
 ## Changelog

--- a/src/Commands/FilterMakeCommand.php
+++ b/src/Commands/FilterMakeCommand.php
@@ -3,12 +3,13 @@
 namespace Pricecurrent\LaravelEloquentFilters\Commands;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 class FilterMakeCommand extends GeneratorCommand
 {
-    protected $signature = 'eloquent-filter:make {name}';
+    protected $signature = 'make:eloquent-filter {name} {--field}';
 
-    protected $description = 'Create a Query Filter Class';
+    protected $description = 'Create a Eloquent Filter Class';
 
     /**
      * The type of class being generated.
@@ -24,17 +25,71 @@ class FilterMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        if ($this->option('field')) {
+            return dirname(__DIR__, 1) . '/stubs/filter.field.stub';
+        }
+
         return dirname(__DIR__, 1) . '/stubs/filter.stub';
     }
 
     /**
      * Get the default namespace for the class.
      *
-     * @param  string  $rootNamespace
+     * @param string $rootNamespace
      * @return string
      */
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace . '\Filters';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name' => InputOption::VALUE_REQUIRED, 'Name of the Filter that should be created'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['field' => InputOption::VALUE_OPTIONAL, 'The name of the Filter field']
+        ];
+    }
+
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param string $name
+     * @return string
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    protected function buildClass($name)
+    {
+        $stub = $this->files->get($this->getStub());
+
+        return $this->replaceNamespace($stub, $name)
+            ->replaceField($stub, $this->option('field'))
+            ->replaceClass($stub, $name);
+    }
+
+    public function replaceField(string &$stub, ?string $field): self
+    {
+        if ($field) {
+            $stub = str_replace('{{ field }}', $field, $stub);
+        }
+
+        return $this;
     }
 }

--- a/src/Commands/FilterMakeCommand.php
+++ b/src/Commands/FilterMakeCommand.php
@@ -7,7 +7,8 @@ use Symfony\Component\Console\Input\InputOption;
 
 class FilterMakeCommand extends GeneratorCommand
 {
-    protected $signature = 'make:eloquent-filter {name} {--field}';
+    protected $signature = 'make:eloquent-filter {name : The name of the filter}
+    {--field= : The name of the Filter that should be created}';
 
     protected $description = 'Create a Eloquent Filter Class';
 

--- a/src/stubs/filter.field.stub
+++ b/src/stubs/filter.field.stub
@@ -1,0 +1,22 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ rootNamespace }}Filters;
+use Illuminate\Database\Eloquent\Builder;
+use Pricecurrent\LaravelEloquentFilters\AbstractEloquentFilter;
+
+class {{ class }} extends AbstractEloquentFilter
+{
+    protected ${{ field }};
+
+    public function __constructor(${{ field }})
+    {
+        $this->{{ field }};
+    }
+
+    public function apply(Builder $query): Builder
+    {
+        return $query->where('{{ field }}', 'like', "$this->{{ field }}%");
+    }
+}

--- a/tests/FilterMakeCommandTest.php
+++ b/tests/FilterMakeCommandTest.php
@@ -32,12 +32,37 @@ class FilterMakeCommandTest extends TestCase
     /**
      * @test
      */
+    public function it_inline_creates_a_filter_class()
+    {
+        Artisan::call("make:eloquent-filter {$this->filterName}");
+
+        $expectedFile = $this->expectedFilesPath('FilterMakerCommand/it_creates_a_filter_class.php');
+        $resultFile = $this->filtersPath("$this->filterName.php");
+
+        $this->assertFileEquals($expectedFile, $resultFile);
+    }
+
+    /**
+     * @test
+     */
     public function it_creates_a_filter_class_with_field_name()
     {
         Artisan::call('make:eloquent-filter', [
             'name' => $this->filterName,
             '--field' => 'name',
         ]);
+        $expectedFile = $this->expectedFilesPath('FilterMakerCommand/it_creates_a_filter_class_with_field_name.php');
+        $resultFile = $this->filtersPath("$this->filterName.php");
+
+        $this->assertFileEquals($expectedFile, $resultFile);
+    }
+
+    /**
+     * @test
+     */
+    public function it_inline_creates_a_filter_class_with_field_name()
+    {
+        Artisan::call("make:eloquent-filter {$this->filterName} --field=name");
         $expectedFile = $this->expectedFilesPath('FilterMakerCommand/it_creates_a_filter_class_with_field_name.php');
         $resultFile = $this->filtersPath("$this->filterName.php");
 

--- a/tests/FilterMakeCommandTest.php
+++ b/tests/FilterMakeCommandTest.php
@@ -17,12 +17,30 @@ class FilterMakeCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_a_fitler_class()
+    public function it_creates_a_filter_class()
     {
-        Artisan::call('eloquent-filter:make', [
+        Artisan::call('make:eloquent-filter', [
             'name' => $this->filterName,
         ]);
 
-        $this->assertTrue(File::exists($this->filtersPath("$this->filterName.php")));
+        $expectedFile = $this->expectedFilesPath('FilterMakerCommand/it_creates_a_filter_class.php');
+        $resultFile = $this->filtersPath("$this->filterName.php");
+
+        $this->assertFileEquals($expectedFile, $resultFile);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_a_filter_class_with_field_name()
+    {
+        Artisan::call('make:eloquent-filter', [
+            'name' => $this->filterName,
+            '--field' => 'name',
+        ]);
+        $expectedFile = $this->expectedFilesPath('FilterMakerCommand/it_creates_a_filter_class_with_field_name.php');
+        $resultFile = $this->filtersPath("$this->filterName.php");
+
+        $this->assertFileEquals($expectedFile, $resultFile);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -35,7 +35,7 @@ class TestCase extends Orchestra
 
     public function getEnvironmentSetUp($app)
     {
-        config()->set('database.default', 'testing');
+        $app['config']->set('database.default', 'testing');
         $this->createTables('filterable_models');
     }
 
@@ -55,8 +55,13 @@ class TestCase extends Orchestra
         });
     }
 
-    public function filtersPath($path = '')
+    public function filtersPath($path = ''): string
     {
         return app_path('Filters' . ($path ? "/$path" : ''));
+    }
+
+    public function expectedFilesPath(string $path): string
+    {
+        return dirname(__FILE__) . '/expectedFiles' . ($path ? "/$path" : '');
     }
 }

--- a/tests/expectedFiles/FilterMakerCommand/it_creates_a_filter_class.php
+++ b/tests/expectedFiles/FilterMakerCommand/it_creates_a_filter_class.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace {{ namespace }};
+namespace App\Filters;
 
-use {{ rootNamespace }}Filters;
+use App\Filters;
 use Illuminate\Database\Eloquent\Builder;
 use Pricecurrent\LaravelEloquentFilters\AbstractEloquentFilter;
 
-class {{ class }} extends AbstractEloquentFilter
+class DummyFilter extends AbstractEloquentFilter
 {
     public function apply(Builder $query)
     {

--- a/tests/expectedFiles/FilterMakerCommand/it_creates_a_filter_class_with_field_name.php
+++ b/tests/expectedFiles/FilterMakerCommand/it_creates_a_filter_class_with_field_name.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filters;
+
+use App\Filters;
+use Illuminate\Database\Eloquent\Builder;
+use Pricecurrent\LaravelEloquentFilters\AbstractEloquentFilter;
+
+class DummyFilter extends AbstractEloquentFilter
+{
+    protected $name;
+
+    public function __constructor($name)
+    {
+        $this->name;
+    }
+
+    public function apply(Builder $query): Builder
+    {
+        return $query->where('name', 'like', "$this->name%");
+    }
+}


### PR DESCRIPTION
- Renamed make command from `eloquent-filter:make` to `make:eloquent-filter` to maintain laravel standard
- Added new paramter option --field to make filter with field name
- Renamed apply argument from apply(Build `$build`) to apply(Build `$query`) to bind with abstract base class
- Refactored unit test instructions
