### PR TITLE
Include return type when making Filter

### DIFF
--- a/src/stubs/filter.stub
+++ b/src/stubs/filter.stub
@@ -7,7 +7,7 @@ use Pricecurrent\LaravelEloquentFilters\AbstractEloquentFilter;
 
 class {{ class }} extends AbstractEloquentFilter
 {
-    public function apply(Builder $query)
+    public function apply(Builder $query): Builder
     {
         // your code
     }

--- a/tests/expectedFiles/FilterMakerCommand/it_creates_a_filter_class.php
+++ b/tests/expectedFiles/FilterMakerCommand/it_creates_a_filter_class.php
@@ -7,7 +7,7 @@ use Pricecurrent\LaravelEloquentFilters\AbstractEloquentFilter;
 
 class DummyFilter extends AbstractEloquentFilter
 {
-    public function apply(Builder $query)
+    public function apply(Builder $query): Builder
     {
         // your code
     }


### PR DESCRIPTION
I made a filter using the `php artisan make:eloquent-filter NameFilter` command (without the `--field` option).

But when I tried to use it I would get the following error:

```
local.ERROR: Declaration of App\Filters\NameFilter::apply(Illuminate\Database\Eloquent\Builder $query) must be compatible with Pricecurrent\LaravelEloquentFilters\AbstractEloquentFilter::apply(Illuminate\Database\Eloquent\Builder $query): Illuminate\Database\Eloquent\Builder {"userId":1,"exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\FatalError(code: 0): Declaration of App\\Filters\\NameFilter::apply(Illuminate\\Database\\Eloquent\\Builder $query) must be compatible with Pricecurrent\\LaravelEloquentFilters\\AbstractEloquentFilter::apply(Illuminate\\Database\\Eloquent\\Builder $query): Illuminate\\Database\\Eloquent\\Builder at /path/to/laravel/app/Filters/NameFilter.php:23)
[stacktrace]
#0 {main}
"} 
```

The stub for creating the Filter without the --field option was missing the `Builder` return type on the `apply` function.

I've fixed that in this PR.